### PR TITLE
Add download instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,11 @@
 # Hubs Blender Files and Creator Labs Archive
 A place to put our share-able Blender files.
 
-This repo is using git lfs to store files: https://docs.github.com/en/repositories/working-with-files/managing-large-files/about-git-large-file-storage
+# Download
+
+This repository uses [Git LFS](https://git-lfs.com/).
+
+If you just want the files to use, please [download them from here](https://drive.google.com/drive/folders/1T8ndbw6o2YTeTsPOJ3FtOLGrpS28CipQ?usp=sharing).
+
+**Contributors:**
+If you want to contribute to the repository, you will need to have Git LFS installed before cloning the repository (don't forget to run `git lfs install` once you've installed it).


### PR DESCRIPTION
Add download section to the readme.
Add link to downloadable assets on the Hubs Foundation's Google Drive.
Add note for contributors that they will need to install Git LFS in order to clone the repository.

GitHub's LFS downloads are expensive, so a copy of the files has been provided on the Hubs Foundation's Google Drive for people to download to help save bandwidth.