### PR TITLE
[Mozilla Branding Removal] Remove Mozilla Swag avatars

### DIFF
--- a/demo-server/hubs_avatars_export/Mozilla_Swag_by_JCo_id_UwlFdZF.gltf
+++ b/demo-server/hubs_avatars_export/Mozilla_Swag_by_JCo_id_UwlFdZF.gltf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8ec2501f825067c83f3df5bf7c218219c416b463fb0bcc800e30b2e4d2ce6e4e
-size 115263

--- a/demo-server/hubs_avatars_export/Mozilla_Swag_by_JCo_id_UwlFdZF.png
+++ b/demo-server/hubs_avatars_export/Mozilla_Swag_by_JCo_id_UwlFdZF.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:177f8c258ebbd9e56aa7d369844f1770c933fb944af289435be4ab61eea5756c
-size 324131

--- a/demo-server/hubs_avatars_export/Mozilla_Swag_by_JCo_id_dm4kmDm.gltf
+++ b/demo-server/hubs_avatars_export/Mozilla_Swag_by_JCo_id_dm4kmDm.gltf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:29140860e19af49d248f0bc5d9277afa0627d07f372e4365a193da93fec941b5
-size 108253

--- a/demo-server/hubs_avatars_export/Mozilla_Swag_by_JCo_id_dm4kmDm.png
+++ b/demo-server/hubs_avatars_export/Mozilla_Swag_by_JCo_id_dm4kmDm.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:177f8c258ebbd9e56aa7d369844f1770c933fb944af289435be4ab61eea5756c
-size 324131


### PR DESCRIPTION
## What?
<!-- REQUIRED — Explain what your pull request does -->
Removes the Mozilla Swag avatar files/texture maps by JCo in the `demo-server/hubs_avatars_export` folder.

## Why?
<!-- REQUIRED — Explain why you're opening this pull request, what limitations does it address, etc..  If you're fixing a bug with an open bug report you can just link to the bug report -->
Hubs is no longer a Mozilla project, so it's not appropriate to distribute Mozilla swag.

## Examples
<!-- OPTIONAL — If applicable, give examples of the changes the user will observe, e.g. screenshots, videos, diagrams, console output, etc., otherwise put "N/A" or remove the section.  Including examples of before the PR and after the PR is encouraged. -->
N/A

## How to test
<!-- REQUIRED — Give the steps required to test your pull request -->

1. See that the files are no longer present.

## Documentation of functionality
<!-- REQUIRED — Link to the accompanying documentation pull request or identify where the documentation is located in this pull request.  If no documentation is needed, please specify this here -->
There is no documentation for this repository that I'm aware of, so no documentation needs to be updated.

## Limitations
<!-- OPTIONAL — If there is anything you decided not to do/support in this PR that might otherwise be expected, list them here along with the reason why you didn't do/support them, otherwise put "None" -->
None.

## Alternative implementations considered
<!-- OPTIONAL — If there are any alternative ways of implementing this change that you thought of, but decided against, list them here along with why they were discarded, otherwise put "None" -->
None.

## Open questions
<!-- OPTIONAL — If you have any questions, put them here, otherwise put "None" -->
None.

## Additional details or related context
<!-- OPTIONAL — If there are any other details that you think the reviewers should be aware of that you didn't put elsewhere, e.g. links to related issues, pull requests, references you used, notes on weird things, attribution, etc., put them here, otherwise put "None" -->

Part of the Mozilla branding removal project: [Repositories for Mozilla Branding Removal](https://docs.google.com/document/d/1bp2GInoMMae4q00gcxAAjmxVtL2hus-WO-YHhppeuvg/edit?tab=t.0)